### PR TITLE
Bump the pip group across 1 directory with 3 updates

### DIFF
--- a/rag_tools/requirements.txt
+++ b/rag_tools/requirements.txt
@@ -1,7 +1,7 @@
 langchain==0.1.13
-langchain-community==0.0.29
+langchain-community==0.2.5
 python-dotenv==1.0.1
-requests==2.31.0
-tqdm==4.66.2
+requests==2.32.2
+tqdm==4.66.3
 unstructured[all-docs]==0.12.6
 web3==6.15.1


### PR DESCRIPTION
Bumps the pip group with 3 updates in the /rag_tools directory: [langchain-community](https://github.com/langchain-ai/langchain), [requests](https://github.com/psf/requests) and [tqdm](https://github.com/tqdm/tqdm).


Updates `langchain-community` from 0.0.29 to 0.2.5
- [Release notes](https://github.com/langchain-ai/langchain/releases)
- [Commits](https://github.com/langchain-ai/langchain/commits/langchain-community==0.2.5)

Updates `requests` from 2.31.0 to 2.32.2
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.31.0...v2.32.2)

Updates `tqdm` from 4.66.2 to 4.66.3
- [Release notes](https://github.com/tqdm/tqdm/releases)
- [Commits](https://github.com/tqdm/tqdm/compare/v4.66.2...v4.66.3)

---
updated-dependencies:
- dependency-name: langchain-community dependency-type: direct:production dependency-group: pip
- dependency-name: requests dependency-type: direct:production dependency-group: pip
- dependency-name: tqdm dependency-type: direct:production dependency-group: pip ...